### PR TITLE
Quick fix to get baselayer working with new tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,8 +113,8 @@
   var heatmapLayer = new HeatmapOverlay(cfg);
 
   var baseLayer = L.tileLayer(
-    'https://{s}.tiles.mapbox.com/v3/cwhong.map-hziyh867/{z}/{x}/{y}.png',{
-      attribution: "<a href='https://www.mapbox.com/about/maps/' target='_blank'>&copy; Mapbox &copy; OpenStreetMap</a> <a class='mapbox-improve-map' href='https://www.mapbox.com/map-feedback/' target='_blank'>Improve this map</a>",
+    'http://tile.stamen.com/toner/{z}/{x}/{y}.png',{
+      attribution: "Map tiles by <a href='http://stamen.com'>Stamen Design</a>, under <a href='http://creativecommons.org/licenses/by/3.0'>CC BY 3.0</a>. Data by <a href='http://openstreetmap.org'>OpenStreetMap</a>, under <a href='http://www.openstreetmap.org/copyright'>ODbL</a>.",
       maxZoom: 18
     }
   );


### PR DESCRIPTION
The baselayer tiles no longer worked, so updated the tile url and attribution statement to use the rather nice Toner mapping from Stamen